### PR TITLE
Force to use mobx@1.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@parity/api": "2.1.x",
     "@parity/etherscan": "2.1.x",
-    "@parity/mobx": "^1.0.4",
+    "@parity/mobx": "1.0.x",
     "@parity/shared": "2.2.x",
     "babel-runtime": "^6.26.0",
     "bignumber.js": "4.1.0",


### PR DESCRIPTION
- `ui@3.0.x` uses `mobx@1.0.x`
- `ui@3.1.x` uses `mobx@1.1.x`