### PR TITLE
Don't use file:// to load images

### DIFF
--- a/src/DappIcon/dappIcon.js
+++ b/src/DappIcon/dappIcon.js
@@ -66,8 +66,7 @@ class DappIcon extends Component {
         if (!this.dappsUrlStore.dappsUrl) return <div className={classes} />; // Blank frame
 
         const dappHost = (process.env.DAPPS_URL || `${this.dappsUrlStore.fullUrl}/ui`).trimRight('/');
-        const fallbackSrc =
-          window.location.protocol === 'file:' ? `dapps/${app.id}/icon.png` : `${dappHost}/dapps/${app.id}/icon.png`;
+        const fallbackSrc = `${dappHost}/dapps/${app.id}/icon.png`;
 
         imageSrc = app.image ? `${dappHost}${app.image}` : fallbackSrc;
         break;

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,8 +105,8 @@
     u2f-api-polyfill "0.4.3"
 
 "@parity/mobx@1.1.x":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@parity/mobx/-/mobx-1.1.1.tgz#86a368ac4ebb482ae06946fee21d0c798b419951"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@parity/mobx/-/mobx-1.1.2.tgz#64e1a732f468560fcc236c7af31d1330c5371c8a"
   dependencies:
     "@parity/jsonrpc" "^2.1.5"
     "@parity/ledger" "^2.1.2"


### PR DESCRIPTION
I propose to always use `http://localhost:8545/path/to/icon.png` to load dapp icons? I.e. remove the file:// protocol to fetch images.

What do you think @jacogr, any contra-indications?

Had a bug with Electron (which has file:// protocol) not loading images. 