### PR TITLE
Fix gas editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "js-sha3": "0.6.1",
     "keycode": "^2.1.9",
     "lodash": "4.17.4",
-    "moment": "2.19.2",
+    "moment": "^2.21.0",
     "qrcode-generator": "1.3.1",
     "react-ace": "5.7.0",
     "react-copy-to-clipboard": "5.0.1",

--- a/src/GasPriceEditor/store.js
+++ b/src/GasPriceEditor/store.js
@@ -26,8 +26,6 @@ const CONDITIONS = {
   TIME: 'timestamp'
 };
 
-let instance;
-
 export default class GasPriceEditor {
   @observable blockNumber = 0;
   @observable condition = {};
@@ -268,14 +266,6 @@ export default class GasPriceEditor {
 
     return result;
   };
-
-  static get (api, transaction) {
-    if (!instance) {
-      instance = new GasPriceEditor(api, transaction);
-    }
-
-    return instance;
-  }
 }
 
 export { CONDITIONS };

--- a/src/Signer/Request/RequestSend/requestSend.js
+++ b/src/Signer/Request/RequestSend/requestSend.js
@@ -30,26 +30,21 @@ import styles from './requestSend.css';
 
 @observer
 export default class RequestSend extends Component {
-  static contextTypes = {
-    api: PropTypes.object.isRequired
-  };
-
   static propTypes = {
     address: PropTypes.string.isRequired,
     className: PropTypes.string,
+    gasPriceStore: PropTypes.object.isRequired,
     transaction: transactionShape.isRequired
   };
 
-  gasStore = GasPriceEditor.Store.get(this.context.api, this.props.transaction);
-
   render () {
-    const { address, className } = this.props;
+    const { address, className, gasPriceStore } = this.props;
     return (
       <div className={[className, styles.method].join(' ')}>
         <MethodDecoding
           address={address}
           historic={false}
-          transaction={this.gasStore.overrideTransaction(this.props.transaction)}
+          transaction={gasPriceStore.overrideTransaction(this.props.transaction)}
         />
 
         <div className={styles.editButtonRow}>
@@ -75,7 +70,7 @@ export default class RequestSend extends Component {
   renderTxEditor () {
     return (
       <Layout>
-        <GasPriceEditor store={this.gasStore} />
+        <GasPriceEditor store={this.props.gasPriceStore} />
       </Layout>
     );
   }

--- a/src/Signer/Request/request.js
+++ b/src/Signer/Request/request.js
@@ -47,7 +47,7 @@ class Request extends Component {
     const { payload } = this.props.request;
     const transaction = payload.sendTransaction || payload.signTransaction;
     if (transaction) {
-      this.gasPriceStore = GasPriceStore.get(this.context.api, transaction);
+      this.gasPriceStore = new GasPriceStore(this.context.api, transaction);
     }
   }
 
@@ -126,7 +126,7 @@ class Request extends Component {
             <Origin origin={origin} />
           </div>
           <div className={styles.details}>
-            <RequestDescription address={address} {...requestData} />
+            <RequestDescription address={address} gasPriceStore={this.gasPriceStore} {...requestData} />
           </div>
         </Layout.Main>
         <Layout.Side>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3291,9 +3291,9 @@ mobx@2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-2.6.4.tgz#e05a91a5b2c97dac3fdab34024e6b74a7f4311ab"
 
-moment@2.19.2:
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"
+moment@^2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Upgrade `moment` package because of security vulnerability
- Fix bug gas limit editor. `gasPriceStore` was a singleton store, so: changing gas limit for one transaction resulted in all transactions using that gas limit, estimated gas was wrong etc... Fixed by using one instance of `gasPriceStore` per request. cc @tomusdrw 