### PR TITLE
DappIcon: Use filesystem path directly for icons of builtin dapps

### DIFF
--- a/src/DappIcon/dappIcon.js
+++ b/src/DappIcon/dappIcon.js
@@ -59,11 +59,8 @@ class DappIcon extends Component {
     if (!this.dappsUrlStore.dappsUrl) return <div className={classes} />; // Blank frame
 
     switch (app.type) {
-      case 'view': {
-        const dappHost = (process.env.DAPPS_URL || `${this.dappsUrlStore.fullUrl}/ui`).trimRight('/');
-        const fallbackSrc = `${dappHost}/dapps/${app.id}/icon.png`;
-
-        imageSrc = app.image ? `${dappHost}${app.image}` : fallbackSrc;
+      case 'builtin': {
+        imageSrc = app.image;
         break;
       }
       case 'local': {
@@ -72,7 +69,6 @@ class DappIcon extends Component {
         imageSrc = `${this.dappsUrlStore.fullUrl}/${app.id}/${app.iconUrl}`;
         break;
       }
-      case 'builtin':
       case 'network':
       default:
         imageSrc = `${this.dappsUrlStore.fullUrl}${app.image}`;

--- a/src/DappIcon/dappIcon.js
+++ b/src/DappIcon/dappIcon.js
@@ -64,9 +64,7 @@ class DappIcon extends Component {
         break;
       }
       case 'local': {
-        if (!this.dappsUrlStore.dappsUrl) return <div className={classes} />; // Blank frame
-
-        imageSrc = `${this.dappsUrlStore.fullUrl}/${app.id}/${app.iconUrl}`;
+        imageSrc = app.image || `${this.dappsUrlStore.fullUrl}/${app.id}/${app.iconUrl}`;
         break;
       }
       case 'network':


### PR DESCRIPTION
For https://github.com/parity-js/shell/pull/114